### PR TITLE
Allow Symfony 4, travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: php
 
 php:
-  - '5.6'
-  - '7.0'
+  - 5.6
+  - 7.0
+  - 7.1
+
+matrix:
+  include:
+    - php: 5.6
+      env: DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 7.1
+      env: DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 install:
-  - composer install
+  - travis_retry composer update $DEPENDENCIES
 
 script:
   - php vendor/bin/parallel-lint ./src ./tests

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     },
     "require": {
-        "symfony/framework-bundle": "^2.5|^3.0",
-        "symfony/http-foundation": "^2.5|^3.0",
+        "symfony/framework-bundle": "^2.5|^3.0|^4.0",
+        "symfony/http-foundation": "^2.5|^3.0|^4.0",
         "phpunit/phpunit": "^3.7.15|^4.0|^5.0"
     },
     "require-dev": {

--- a/src/RequestDataSet.php
+++ b/src/RequestDataSet.php
@@ -205,7 +205,7 @@ class RequestDataSet implements RequestDataSetConfig
      * @param \Shopsys\HttpSmokeTesting\RequestDataSet $requestDataSet
      * @return $this
      */
-    public function mergeExtraValuesFrom(RequestDataSet $requestDataSet)
+    public function mergeExtraValuesFrom(self $requestDataSet)
     {
         if ($requestDataSet->auth !== null) {
             $this->setAuth($requestDataSet->getAuth());


### PR DESCRIPTION
**Description, reason for the PR:** 
- having composer.lock in library is meaningless, it also makes pull requests harder due to possible conflicts (see https://getcomposer.org/doc/02-libraries.md#lock-file ) and the tests will not run against latest releases of depending libraries
- symfony 4 is already in beta, would be nice to allow its installation
- added build on PHP 7.1 and also lowest dependencies build - see https://evertpot.com/testing-composer-prefer-lowest/
- php-cs-fixer changes behavior of self_ancestor check, thus the "self" in codestyle

**New feature:** No
**BC breaks:** No
**Standards and tests pass:** We will see
**Licence:** MIT
