### PR TITLE
Allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.2",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
There seem to be no changes in the API that smoke tests use:
https://phpunit.de/announcements/phpunit-9.html